### PR TITLE
Heroku Deployment

### DIFF
--- a/server/config/config.json
+++ b/server/config/config.json
@@ -14,10 +14,7 @@
     "dialect": "mysql"
   },
   "production": {
-    "username": "root",
-    "password": null,
-    "database": "database_production",
-    "host": "127.0.0.1",
+    "use_env_variable": "JAWSDB_URL",
     "dialect": "mysql"
   }
 }


### PR DESCRIPTION
- adding stuff to config file for heroku deployment
    * uses JAWS_DB for MySQL action.